### PR TITLE
feat: Add SLA validation to ChainRegistry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.vscode

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -47,6 +47,13 @@ impl SLA {
     }
 }
 
+/// Additional SLA configuration struct that may be useful for auction time validation.
+#[derive(Clone, Debug)]
+pub struct SLAConfig {
+    /// The minimal offset (in milliseconds) between `start_time` and `end_time` for an auction.
+    pub min_end_time_offset_ms: u64,
+}
+
 /// Represents the state of an auction, including the SLA, current highest bid, winner, all bids, and whether it is ended.
 #[derive(Debug, Clone)]
 pub struct AuctionState {

--- a/src/services/chain_registry.rs
+++ b/src/services/chain_registry.rs
@@ -1,4 +1,6 @@
 use crate::domain::ChainId;
+use crate::domain::SLAConfig;
+use crate::domain::SLA;
 use std::collections::HashMap;
 
 #[derive(Default)]
@@ -7,6 +9,10 @@ pub struct ChainRegistry {
     pub max_gas_limit: HashMap<ChainId, u64>,
     /// A mapping of `ChainId` to a list of valid (registered) seller addresses.
     pub registered_sellers: HashMap<ChainId, Vec<String>>,
+    /// A mapping of `ChainId` to the current block height.
+    pub current_block_height: HashMap<ChainId, u64>,
+    /// A mapping of `ChainId` to SLA-related configuration parameters.
+    pub sla_config: HashMap<ChainId, SLAConfig>,
 }
 
 impl ChainRegistry {
@@ -19,9 +25,22 @@ impl ChainRegistry {
         let mut registered_sellers = HashMap::new();
         registered_sellers.insert(1, vec!["0xSellerAddress".to_string()]);
 
+        let mut current_block_height = HashMap::new();
+        current_block_height.insert(1, 10_000u64);
+
+        let mut sla_config = HashMap::new();
+        sla_config.insert(
+            1,
+            SLAConfig {
+                min_end_time_offset_ms: 500,
+            },
+        );
+
         ChainRegistry {
             max_gas_limit,
             registered_sellers,
+            current_block_height,
+            sla_config,
         }
     }
 
@@ -37,8 +56,69 @@ impl ChainRegistry {
             .map_or(false, |sellers| sellers.contains(&seller.to_string()))
     }
 
+    /// Validates the SLA for the specified chain.
+    pub fn is_valid_sla(&self, chain_id: ChainId, sla: &SLA, recent_sla: &SLA) -> bool {
+        self.is_valid_seller(chain_id, &sla.seller_addr)
+            && self.validate_future_block_height(chain_id, recent_sla)
+            && self.is_below_chain_gas_limit(chain_id, sla.blockspace_size)
+            && self.is_future_start_time(sla.start_time)
+            && self.validate_end_time_offset(chain_id, sla.start_time, sla.end_time)
+    }
+
     /// Retrieves the maximum gas limit for the specified chain.
     pub fn get_max_gas_limit(&self, chain_id: ChainId) -> Option<u64> {
         self.max_gas_limit.get(&chain_id).copied()
+    }
+
+    /// Retrieves the current block height for the specified chain, if available.
+    pub fn get_current_block_height(&self, chain_id: ChainId) -> Option<u64> {
+        self.current_block_height.get(&chain_id).copied()
+    }
+
+    /// Updates the current block height for the specified chain.
+    pub fn update_current_block_height(&mut self, chain_id: ChainId, height: u64) {
+        self.current_block_height.insert(chain_id, height);
+    }
+
+    /// Fetches the SLA configuration for the specified chain.
+    pub fn get_sla_config(&self, chain_id: ChainId) -> Option<&SLAConfig> {
+        self.sla_config.get(&chain_id)
+    }
+
+    /// Validates that the specified block height is greater than the most recent auction's block height.
+    pub fn validate_future_block_height(&self, chain_id: ChainId, recent_sla: &SLA) -> bool {
+        recent_sla.block_height < self.get_current_block_height(chain_id).unwrap_or(0)
+    }
+
+    /// Checks whether the given blockspace size is below or equal to the max gas limit of the specified chain.
+    pub fn is_below_chain_gas_limit(&self, chain_id: ChainId, blockspace_size: u64) -> bool {
+        if let Some(max_gas) = self.get_max_gas_limit(chain_id) {
+            blockspace_size <= max_gas
+        } else {
+            false
+        }
+    }
+
+    /// Checks if the start_time is strictly greater than the provided current_time (i.e., it is in the future).
+    pub fn is_future_start_time(&self, start_time: u64) -> bool {
+        let current_time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        start_time > current_time
+    }
+
+    /// Checks if the end_time meets the minimal offset requirement (e.g., 500ms) after the start_time for the given chain.
+    pub fn validate_end_time_offset(
+        &self,
+        chain_id: ChainId,
+        start_time: u64,
+        end_time: u64,
+    ) -> bool {
+        if let Some(cfg) = self.get_sla_config(chain_id) {
+            end_time >= start_time + cfg.min_end_time_offset_ms
+        } else {
+            false
+        }
     }
 }


### PR DESCRIPTION
[Registry Worker 설계상](https://atlantic-walker-f10.notion.site/Lighthouse-18480630c8b2468dab18953bd459ed3d)의 입력 데이터 검증 요구사항에 맞춰 `ChainRegistry`에 추가 field 및 method를 구현합니다.

### Fields
- 체인별 현재 블록 높이: `current_block_height`
- SLA 관련 설정(경매 시간): `sla_config`
  - `domain.rs`에 `SLAConfig` struct 정의 추가

### Methods
입력 데이터 검증: `is_valid_sla`
- Lighthouse 체인에 등록된 Chain ID와 동일한가: `is_valid_seller` (이미 구현되어있음)
- 가장 최근 Auction 정보보다 Block height가 큰가: `validate_future_block_height`
- SLA에서 정의된 Gas limit이 체인의 Gas limit보다 작은가: `is_below_chain_gas_limit`
- 경매 시작 시간이 현재보다 미래인가: `is_future_start_time`
- 경매 종료 시간이 경매 시작 시간보다 500ms 이상 미래인가: `validate_end_time_offset`